### PR TITLE
[BE Feat] #52. Item 상세정보 api GET 요청 구현완료.

### DIFF
--- a/server/src/main/java/com/seb_main_002/item/controller/ItemController.java
+++ b/server/src/main/java/com/seb_main_002/item/controller/ItemController.java
@@ -1,10 +1,12 @@
 package com.seb_main_002.item.controller;
 
 import com.seb_main_002.item.dto.ItemPostDto;
+import com.seb_main_002.item.dto.ItemSimpleResponseDto;
 import com.seb_main_002.item.dto.ItemTopListResponseDto;
 import com.seb_main_002.item.entity.Item;
 import com.seb_main_002.item.mapper.ItemMapper;
 import com.seb_main_002.item.service.ItemService;
+import com.seb_main_002.review.entity.Review;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,5 +74,43 @@ public class ItemController {
         return new ResponseEntity<>(response,HttpStatus.OK);
     }
 
+    @GetMapping("/{itemId}")
+    public ResponseEntity getItem(@PathVariable("itemId") Long itemId){
+        Item item = itemService.findItem(itemId);
+        List<Review> reivews = item.getReviews();
+
+        ItemSimpleResponseDto.ItemInfo itemInfo = ItemSimpleResponseDto.ItemInfo.builder()
+                .itemId(item.getItemId())
+                .itemTitle(item.getItemTitle())
+                .categoryKRName(item.getCategoryKRName())
+                .titleImageURL(item.getTitleImageUrl())
+                .contentImageURL(item.getContentImageUrl())
+                .content(item.getContent())
+                .price(item.getPrice())
+                .tagList(item.getTagList())
+                .rating(item.getRating())
+                .build();
+
+        List<ItemSimpleResponseDto.ItemReviewResponseDto> responseReviews = reivews.stream()
+                .map(review -> ItemSimpleResponseDto.ItemReviewResponseDto.builder()
+                        .memberId(review.getMember().getMemberId())
+                        .accountId(review.getMember().getAccountId())
+                        .reviewId(review.getReviewId())
+                        .reviewContent(review.getReviewContent())
+                        .createdAt(review.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd/HH:mm")))
+                        .modifiedAt(review.getModifiedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd/HH:mm")))
+                        .reviewRating(review.getReviewRating())
+                        .build())
+                .collect(Collectors.toList());
+
+        ItemSimpleResponseDto response = ItemSimpleResponseDto.builder()
+                .iteminfo(itemInfo)
+                .reviews(responseReviews)
+                .build();
+
+
+        return new ResponseEntity<>(response,HttpStatus.OK);
+
+    }
 
 }

--- a/server/src/main/java/com/seb_main_002/item/controller/ItemController.java
+++ b/server/src/main/java/com/seb_main_002/item/controller/ItemController.java
@@ -49,12 +49,26 @@ public class ItemController {
 
     @GetMapping("/toplist/{categoryENName}")
     public ResponseEntity getItems(@PathVariable("categoryENName") String categoryENName){
+
         List<Item> items = itemService.findTopListItems(categoryENName);
-        List<ItemTopListResponseDto> response = items.stream()
-                .map(item -> new ItemTopListResponseDto(item))
+        List<ItemTopListResponseDto.TopItemDto> topItemDtos = items.stream()
+                .map(item -> ItemTopListResponseDto.TopItemDto.builder()
+                        .itemId(item.getItemId())
+                        .itemTitle(item.getItemTitle())
+                        .categoryKRName(item.getCategoryKRName())
+                        .categoryENName(item.getCategoryENName())
+                        .titleImageURL(item.getTitleImageUrl())
+                        .price(item.getPrice())
+                        .salesCount(item.getSalesCount())
+                        .tagsList(item.getTagList())
+                        .build())
                 .collect(Collectors.toList());
 
-        return new ResponseEntity<>(new ItemTopListResponseDto.Response(response),HttpStatus.OK);
+        ItemTopListResponseDto response = ItemTopListResponseDto.builder()
+                .topList(topItemDtos)
+                .build();
+
+        return new ResponseEntity<>(response,HttpStatus.OK);
     }
 
 

--- a/server/src/main/java/com/seb_main_002/item/dto/ItemSimpleResponseDto.java
+++ b/server/src/main/java/com/seb_main_002/item/dto/ItemSimpleResponseDto.java
@@ -1,4 +1,43 @@
 package com.seb_main_002.item.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+
+@Builder
+@Getter
 public class ItemSimpleResponseDto {
+    ItemInfo iteminfo;
+
+    List<ItemReviewResponseDto> reviews;
+
+    @Builder
+    @Getter
+    public static class ItemInfo{
+        private Long itemId;
+        private String itemTitle;
+        private String categoryKRName;
+        private String titleImageURL;
+        private String contentImageURL;
+        private String content;
+        private Integer price;
+        private List<String> tagList;
+        private Double rating;
+    }
+
+    @Builder
+    @Getter
+    public static class ItemReviewResponseDto{
+        private Long memberId;
+        private String accountId;
+        private Long reviewId;
+        private String reviewTitle;
+        private String reviewContent;
+        private String createdAt;
+        private String modifiedAt;
+        private Double reviewRating;
+    }
 }

--- a/server/src/main/java/com/seb_main_002/item/dto/ItemTopListResponseDto.java
+++ b/server/src/main/java/com/seb_main_002/item/dto/ItemTopListResponseDto.java
@@ -1,38 +1,42 @@
 package com.seb_main_002.item.dto;
 
 import com.seb_main_002.item.entity.Item;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
+@Builder
 @Getter
 public class ItemTopListResponseDto {
 
-    private Long itemId;
-    private String itemTitle;
-    private String categoryKRName;
-    private String categoryENName;
-    private String titleImageURL;
-    private Integer price;
-    private Integer salesCount;
-    private List<String> tagsList;
+    List<TopItemDto> topList;
 
-    public ItemTopListResponseDto(Item item) {
-        this.itemId = item.getItemId();
-        this.itemTitle = item.getItemTitle();
-        this.categoryKRName = item.getCategoryKRName();
-        this.categoryENName = item.getCategoryENName();
-        this.titleImageURL = item.getTitleImageUrl();
-        this.price = item.getPrice();
-        this.salesCount = item.getSalesCount();
-        this.tagsList = item.getTagList();
+    public ItemTopListResponseDto(List<TopItemDto> topList){
+        this.topList = topList;
     }
+
+    @Builder
     @Getter
-    public static class Response {
-        List<ItemTopListResponseDto> topList;
-        public Response(List<ItemTopListResponseDto> topList){
-            this.topList = topList;
+    public static class TopItemDto{
+        private Long itemId;
+        private String itemTitle;
+        private String categoryKRName;
+        private String categoryENName;
+        private String titleImageURL;
+        private Integer price;
+        private Integer salesCount;
+        private List<String> tagsList;
+
+        public TopItemDto(Item item){
+            this.itemId = item.getItemId();
+            this.itemTitle = item.getItemTitle();
+            this.categoryKRName = item.getCategoryKRName();
+            this.categoryENName = item.getCategoryENName();
+            this.titleImageURL = item.getTitleImageUrl();
+            this.price = item.getPrice();
+            this.salesCount = item.getSalesCount();
+            this.tagsList = item.getTagList();
         }
     }
-
 }

--- a/server/src/main/java/com/seb_main_002/item/dto/ItemTopListResponseDto.java
+++ b/server/src/main/java/com/seb_main_002/item/dto/ItemTopListResponseDto.java
@@ -28,15 +28,5 @@ public class ItemTopListResponseDto {
         private Integer salesCount;
         private List<String> tagsList;
 
-        public TopItemDto(Item item){
-            this.itemId = item.getItemId();
-            this.itemTitle = item.getItemTitle();
-            this.categoryKRName = item.getCategoryKRName();
-            this.categoryENName = item.getCategoryENName();
-            this.titleImageURL = item.getTitleImageUrl();
-            this.price = item.getPrice();
-            this.salesCount = item.getSalesCount();
-            this.tagsList = item.getTagList();
-        }
     }
 }


### PR DESCRIPTION
단일 아이템의 상세정보에 대한 api GET 요청을 구현했습니다.
 API 명세 : /api/items/{itemId}
ItemSimpleResponseDto 객체를 만들고, 빌더패턴을 이용해 item 정보와 매핑했습니다.

추가로 작업한것 : 
topList 에 대한 api GET 요청에대해 dto 코드를 알아보기쉽게 리팩토링했습니다. 또한, 기존의 생성자로 매핑하는 대신 빌더패턴으로 매핑할 수 있도록 변경했습니다.