### PR TITLE
[BE Fix] item list 전체카테고리 조회시 오류 수정

### DIFF
--- a/server/src/main/java/com/seb_main_002/item/repository/ItemRepository.java
+++ b/server/src/main/java/com/seb_main_002/item/repository/ItemRepository.java
@@ -6,23 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 public interface ItemRepository extends JpaRepository<Item, Long> {
     Page<Item> findAllByCategoryENName(String categoryENName, Pageable pageable);
 
-    @Query(value = "SELECT ITEM_ID, CREATED_AT, LAST_MODIFIED_AT, CATEGORYENNAME, CATEGORYKRNAME, CONTENT, CONTENT_IMAGE_URL, ITEM_TITLE, PRICE, SALES_COUNT, RATING,TITLE_IMAGE_URL\n" +
-            "FROM ITEM LEFT JOIN ITEM_TAG_LIST ON ITEM.ITEM_ID =ITEM_TAG_LIST.ITEM_ITEM_ID\n" +
-            "WHERE TAG_LIST = :tag1 \n" +
-            "OR TAG_LIST = :tag2\n" +
-            "AND CATEGORYENNAME LIKE :categoryENName% \n" +
-            "AND ITEM_TITLE LIKE %:title% \n" +
-            "GROUP BY ITEM_ID\n" +
-            "HAVING COUNT(ITEM_ID) >1", nativeQuery = true)
-    Page<Item> findByCustomItem(String tag1, String tag2, String categoryENName, String title, Pageable pageable);
+    Page<Item> findAllByCategoryENNameStartingWithAndItemTitleContaining(String categoryENName, String title, Pageable pageable);
 
-    Page<Item> findAllByCategoryENNameContainingAndItemTitleContaining(String categoryENName, String title, Pageable pageable);
+    @Query(value = "SELECT i FROM Item i INNER JOIN i.tagList t WHERE t = :tag1 OR t = :tag2 AND i.itemTitle LIKE %:title% AND i.categoryENName LIKE :categoryENName% GROUP BY i.itemId HAVING count(i.itemId)>1")
+    Page<Item> findCustomItem(String tag1,String tag2, String title, String categoryENName, Pageable pageable);
 
 }

--- a/server/src/main/java/com/seb_main_002/item/service/ItemService.java
+++ b/server/src/main/java/com/seb_main_002/item/service/ItemService.java
@@ -74,14 +74,12 @@ public class ItemService {
 
     public List<Item> findFilteredItems(String categoryENName, Boolean custom, String title, int page){
 
-
         Page<Item> findItems;
         if(custom == false){
-            findItems = itemRepository.findAllByCategoryENNameContainingAndItemTitleContaining(categoryENName,title, PageRequest.of(page,18));
+            findItems = itemRepository.findAllByCategoryENNameStartingWithAndItemTitleContaining(categoryENName,title, PageRequest.of(page,18));
         }
         else{
             List<String> membertags = memberRepository.findById(1L).orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)).getTagList();
-            //List<String> membertags = List.of("건성","일반피부");
             String tag1="", tag2="";
             if     (membertags.contains("건성")){ tag1 = "건성";}
             else if(membertags.contains("지성")){ tag1 = "지성";}
@@ -90,11 +88,9 @@ public class ItemService {
             if     (membertags.contains("일반피부")){ tag2 = "일반피부";}
             else if(membertags.contains("여드름성 피부")){ tag2 = "여드름성 피부";}
 
-            //tag stub 넣어서확인
-            tag1 = "건성";
-            tag2 = "일반피부";
-            findItems = itemRepository.findByCustomItem(tag1, tag2, categoryENName,title,PageRequest.of(page,18));
+                findItems = itemRepository.findCustomItem(tag1, tag2, title,categoryENName, PageRequest.of(page,18));
         }
+
         return findItems.getContent();
     }
     public Item findVerifiedItem(Long itemId){


### PR DESCRIPTION
1. native query문을 사용해서 전체카테고리를 조회시 해결할수 없는 오류가 자꾸 발생해 nativequery -> jpql로 코드를 변경하였습니다.
2. 카테고리명을 cream으로 놓고 검색시 suncream제품도 같이 조회되는 오류를 해결했습니다.