### PR TITLE
[BE Fix] 상품 Top 리스트 페이지 상품 리스트 페이지 멤버태그 로그인한 유저기반으로 나오도록 수정완료

### DIFF
--- a/server/src/main/java/com/seb_main_002/item/controller/ItemController.java
+++ b/server/src/main/java/com/seb_main_002/item/controller/ItemController.java
@@ -6,16 +6,19 @@ import com.seb_main_002.item.mapper.ItemMapper;
 import com.seb_main_002.item.service.ItemService;
 import com.seb_main_002.member.service.MemberService;
 import com.seb_main_002.review.entity.Review;
+import com.seb_main_002.security.jwt.JwtVerificationFilter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.Positive;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -26,10 +29,13 @@ public class ItemController {
     private final MemberService memberService;
     private final ItemMapper mapper;
 
-    public ItemController(ItemService itemService, MemberService memberService, ItemMapper mapper) {
+    private final JwtVerificationFilter jwtVerificationFilter;
+
+    public ItemController(ItemService itemService, MemberService memberService, ItemMapper mapper, JwtVerificationFilter jwtVerificationFilter) {
         this.itemService = itemService;
         this.memberService = memberService;
         this.mapper = mapper;
+        this.jwtVerificationFilter = jwtVerificationFilter;
     }
 
     @PostMapping
@@ -133,12 +139,16 @@ public class ItemController {
     public ResponseEntity getFilteredItems(@PathVariable("categoryENName") String categoryENName,
                                            @RequestParam(required = false) Boolean custom,
                                            @RequestParam(required = false) String title,
-                                           @RequestParam @Positive int page){
+                                           @RequestParam @Positive int page,
+                                           HttpServletRequest request){
         if(categoryENName.equals("all")) categoryENName = "";
         if(custom == null) custom = false;
         if(title == null) title = "";
         page -= 1;
 
+
+//        Map<String, Object> response = jwtVerificationFilter.verifyJws(request);
+  //      Long memberId = ((Number)response.get("memberId")).longValue();
 
         List<String> memberTagsList = new ArrayList<>(List.of("건성", "일반피부"));
         //List<String> memberTagsList = memberService.getLoginUserWithToken().getTagList() == null?null:memberService.getLoginUserWithToken().getTagList();

--- a/server/src/main/java/com/seb_main_002/item/service/ItemService.java
+++ b/server/src/main/java/com/seb_main_002/item/service/ItemService.java
@@ -64,13 +64,9 @@ public class ItemService {
     public List<Item> findTopListItems(String categoryENName, Boolean custom, List<String> memberTagsList){
         if(categoryENName.equals("all")) categoryENName = "";
         Page<Item> findItems;
-        if(custom == false) {
-            findItems = itemRepository.findAllByCategoryENNameStartingWith(categoryENName, PageRequest.of(0, 10, Sort.by("salesCount").descending()));
-        }
-        else {
+
+        if(custom == true && memberTagsList.size() != 0){
             List<String> membertags = memberTagsList;
-            if(membertags == null || membertags.size() == 0)
-                throw new BusinessLogicException(ExceptionCode.UNAUTHORIZED); //이게 응답까지 안날라고 내부적으로 발생한뒤 500쏨. 추후 문제해결할것.
 
             String tag1="", tag2="";
             if     (membertags.contains("건성")){ tag1 = "건성";}
@@ -82,19 +78,19 @@ public class ItemService {
 
             findItems = itemRepository.findCustomTopListItem(tag1,tag2,categoryENName,PageRequest.of(0, 10, Sort.by("salesCount").descending()));
         }
+        else{
+            findItems = itemRepository.findAllByCategoryENNameStartingWith(categoryENName, PageRequest.of(0, 10, Sort.by("salesCount").descending()));
+        }
+
         return findItems.getContent();
     }
 
     public List<Item> findFilteredItems(String categoryENName, Boolean custom, String title, int page, List<String> memberTagsList){
 
         Page<Item> findItems;
-        if(custom == false){
-            findItems = itemRepository.findAllByCategoryENNameStartingWithAndItemTitleContaining(categoryENName,title, PageRequest.of(page,18));
-        }
-        else{
+
+        if(custom == true && memberTagsList.size() != 0){
             List<String> membertags = memberTagsList;
-            if(membertags == null || membertags.size() == 0)
-                throw new BusinessLogicException(ExceptionCode.UNAUTHORIZED); //이게 응답까지 안날라고 내부적으로 발생한뒤 500쏨. 추후 문제해결할것.
 
             String tag1="", tag2="";
             if     (membertags.contains("건성")){ tag1 = "건성";}
@@ -105,6 +101,9 @@ public class ItemService {
             else if(membertags.contains("여드름성 피부")){ tag2 = "여드름성 피부";}
 
                 findItems = itemRepository.findCustomItem(tag1, tag2, title,categoryENName, PageRequest.of(page,18));
+        }
+        else{
+            findItems = itemRepository.findAllByCategoryENNameStartingWithAndItemTitleContaining(categoryENName,title, PageRequest.of(page,18));
         }
 
         return findItems.getContent();


### PR DESCRIPTION
구현한 기능
- 상품 Top 리스트페이지와 상품리스트 페이지에서 try catch문을 이용해 로그인/비로그인 여부를 알아내도록 했습니다.
- verifyJws 문을 통해 memberId정보를 뽑아옵니다.

문제점 및 개선사항
- 상품 Top 리스트페이지와 상품리스트 페이지가 상당히 유사하고 중복되는 코드가 많습니다.
- 많은 if문으로 가독성이 떨어진다고 생각합니다.

this close #131 