### PR TITLE
[Be Refactor] access-token 및 idcheck 관련 로직 수정

### DIFF
--- a/server/src/main/java/com/seb_main_002/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_002/member/controller/MemberController.java
@@ -81,23 +81,12 @@ public class MemberController {
     Map<String, Object> response = new HashMap<>();
     @GetMapping("/user/access-token")
     public ResponseEntity accessToken(HttpServletRequest request) {
-        String accessToken = "";
-        accessToken = request.getHeader("Authorization");
-        if ((!accessToken.equals(""))) {
-            try {
                 Map<String, Object> claims = jwtVerificationFilter.verifyJws(request);
                 Map<String, Object> response = new HashMap<>();
                 response.put("accountId",claims.get("accountId"));
                 response.put("memberId",claims.get("memberId"));
                 return new ResponseEntity(response,HttpStatus.OK);
-
-            } catch (Exception e) {
-                return new ResponseEntity(HttpStatus.UNAUTHORIZED);
-            }
-        } else {
-            return new ResponseEntity(HttpStatus.FORBIDDEN);
         }
-    }
     @GetMapping("/idcheck/{accountId}")
     public ResponseEntity accountIdCheck(@PathVariable("accountId") String accountId) {
         Boolean aBoolean = memberService.verifyExistsAccountId(accountId);

--- a/server/src/main/java/com/seb_main_002/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_002/member/service/MemberService.java
@@ -77,10 +77,12 @@ public class MemberService {
     }
     public Boolean verifyExistsAccountId(String accountId) {
         Optional<Member> optionalMember = memberRepository.findByAccountId(accountId);
+        Boolean isExisted = false;
         if(optionalMember.isPresent()) {
-            return false;
+            isExisted = true;
+            return isExisted; // 중복이면 true
         }
-        return true;
+        return isExisted; // 중복 아니면 false
     }
 
     public Member findMember(Long memberId) {
@@ -105,8 +107,8 @@ public class MemberService {
     @Transactional
     public Member createMember(Member member) {
         verifyExistsEmail(member.getEmail());
-        Boolean aBoolean = verifyExistsAccountId(member.getAccountId());
-        if(aBoolean == false) {
+        Boolean isExisted = verifyExistsAccountId(member.getAccountId());
+        if(isExisted == true) {
             throw new BusinessLogicException(ExceptionCode.ACCOUNTID_EXISTS);
         }
         //암호 인코딩 후 저장

--- a/server/src/main/java/com/seb_main_002/security/CustomUserDetailsService.java
+++ b/server/src/main/java/com/seb_main_002/security/CustomUserDetailsService.java
@@ -33,8 +33,8 @@ public class CustomUserDetailsService implements UserDetailsService {
         return new MemberDetails(member);
     }
 
-        private final class MemberDetails extends Member implements UserDetails {
-            // (1)
+        public final class MemberDetails extends Member implements UserDetails {
+
             MemberDetails(Member member) {
                 setMemberId(member.getMemberId());
                 setAccountId(member.getAccountId());

--- a/server/src/main/java/com/seb_main_002/security/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/seb_main_002/security/config/SecurityConfiguration.java
@@ -62,7 +62,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(authorize -> authorize
                         //.antMatchers(HttpMethod.PATCH,"/api/v1/home").hasRole("ADMIN")
                         //.antMatchers(HttpMethod.DELETE,"/api/v1/home").hasRole("ADMIN")
-                        .antMatchers("/api/v1/signup", "/api/v1/login", "/api/v1/home", "/api/v1/idcheck/**").permitAll() //회원가입, 로그인, 홈 누구나 가능
+                        .antMatchers("/api/v1/signup", "/api/v1/login", "/api/v1/home", "/api/v1/idcheck/**").permitAll() // aws 추가
                         .antMatchers("/api/v1/orders/**").hasRole("USER") // 주문은 유저만 가능
                         .antMatchers("/api/v1/members/**").hasAnyRole("ADMIN","USER") // 멤버정보는 유저, 어드민 가능
                         .antMatchers(HttpMethod.GET, "/api/v1/reviews/**").permitAll() // 리뷰 읽기 누구나 가능
@@ -80,7 +80,7 @@ public class SecurityConfiguration {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         //configuration.setAllowedOrigins(Arrays.asList("*"));
-        configuration.setAllowedOrigins(Arrays.asList("http://seb41team02.s3-website.ap-northeast-2.amazonaws.com","http://localhost:3000")); // 프론트엔드 쪽 서버 주소 -> 추후 aws주소 추가하기
+        configuration.setAllowedOrigins(Arrays.asList("http://seb41team02.s3-website.ap-northeast-2.amazonaws.com","http://localhost:3000")); // aws 추가
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE"));
         configuration.setAllowCredentials(true);       // 내 서버가 응답할 때 json을 JS에서 처리할 수 있게 설정
         configuration.addAllowedHeader("*");           // 모든 header에 응답 허용

--- a/server/src/main/java/com/seb_main_002/security/jwt/JwtReIssueFilter.java
+++ b/server/src/main/java/com/seb_main_002/security/jwt/JwtReIssueFilter.java
@@ -1,0 +1,87 @@
+package com.seb_main_002.security.jwt;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seb_main_002.exception.BusinessLogicException;
+import com.seb_main_002.exception.ExceptionCode;
+import com.seb_main_002.member.entity.Member;
+import com.seb_main_002.security.CustomUserDetailsService;
+import com.seb_main_002.security.CustomUserDetailsService.MemberDetails;
+import com.seb_main_002.security.redis.RedisService;
+import com.seb_main_002.security.util.ErrorResponder;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.SignatureException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class JwtReIssueFilter extends OncePerRequestFilter {
+
+    private final RedisService redisService;
+    private final JwtTokenizer jwtTokenizer;
+    private final CustomUserDetailsService customUserDetailsService;
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        String refreshToken = request.getHeader("Refresh");
+        return !requestURI.equals("/api/v1/user/refresh-token") || !StringUtils.hasText(refreshToken);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            //헤더에 존재하는 refreshToken를 검증하고 레디스에 저장된 refreshToken과 accountId로 accessToken을 만들어서 발급한다.
+
+            String refreshToken = request.getHeader("Refresh");
+            String encodeBase64SecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+            jwtTokenizer.getClaims(refreshToken, encodeBase64SecretKey);
+            String accountId = redisService.getRefreshToken(refreshToken);
+            MemberDetails memberDetails = (MemberDetails) customUserDetailsService.loadUserByUsername(accountId);
+
+            String accessToken = delegateAccessToken(memberDetails, encodeBase64SecretKey);
+
+            response.setHeader("Authorization","Bearer " + accessToken);
+
+            response.setContentType("application/json");
+            response.setCharacterEncoding("utf-8");
+
+            TokenInfo tokenInfo = TokenInfo.builder()
+                    .accessToken("Bearer " + accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+            ObjectMapper objectMapper = new ObjectMapper();
+            response.getWriter().write(objectMapper.writeValueAsString(tokenInfo));
+
+        } catch (ExpiredJwtException jwtException) {
+            request.setAttribute("exception", jwtException);
+        } catch (Exception e) {
+            request.setAttribute("exception", e);
+        }
+        //filterChain.doFilter(request,response); // request 헤더에 엑세스토큰이 없기에 엑세스토큰 검증하는 필터로 보내지 않았습니다.
+    }
+    public String delegateAccessToken(MemberDetails memberDetails, String encodeBase64SecretKey) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("memberId", memberDetails.getMemberId());
+        claims.put("accountId", memberDetails.getAccountId());
+        claims.put("roles",memberDetails.getRoles());
+        String subject = memberDetails.getAccountId();
+        Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+        String accessToken = jwtTokenizer.generateAccessToken(claims, subject, expiration, base64EncodedSecretKey);
+        return accessToken;
+    }
+}

--- a/server/src/main/java/com/seb_main_002/security/jwt/JwtVerificationFilter.java
+++ b/server/src/main/java/com/seb_main_002/security/jwt/JwtVerificationFilter.java
@@ -65,7 +65,7 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
         String jws = request.getHeader("Authorization").replace("Bearer ", "");
         // 만약 블랙리스트로 등록되어있다면 에러발생
         if (StringUtils.hasText(redisService.getAccessToken(jws))) {
-            throw new BusinessLogicException(ExceptionCode.NOT_IMPLEMENTATION);
+            throw new BusinessLogicException(ExceptionCode.UNAUTHORIZED);
         }
         String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
         Map<String, Object> claims = jwtTokenizer.getClaims(jws, base64EncodedSecretKey).getBody();


### PR DESCRIPTION
access-token 검증을 필터에서 거치기에 컨트롤러에서 다시 검증하는 로직 제거

id중복확인시 지역변수를 추가하여 가독성을 높이고 중복 존재 시 true, 중복이 없다면 false를 반환하도록 변경하였습니다.