### PR TITLE
[BE Fix] 회원 정보 수정 이메일 검증 로직 수정. 

### DIFF
--- a/server/src/main/java/com/seb_main_002/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_002/member/service/MemberService.java
@@ -93,7 +93,7 @@ public class MemberService {
         Member verifedMember = verifyMember(memberId);
 
         // 기존 이메일과 동일할 경우에는 유효성 검증을 하지 않도록 수정하였습니다.
-        if(member.getEmail() != verifedMember.getEmail()) {
+        if(!member.getEmail().equals(verifedMember.getEmail())) {
             verifyExistsEmail(member.getEmail());
         }
         Optional.ofNullable(member.getName())

--- a/server/src/main/java/com/seb_main_002/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_002/member/service/MemberService.java
@@ -91,8 +91,9 @@ public class MemberService {
     @Transactional
     public void updateMember(Long memberId, Member member) {
         Member verifedMember = verifyMember(memberId);
-        // 이메일 변경 요청시에만 검증하도록
-        if(member.getEmail()!=null) {
+
+        // 기존 이메일과 동일할 경우에는 유효성 검증을 하지 않도록 수정하였습니다.
+        if(member.getEmail() != verifedMember.getEmail()) {
             verifyExistsEmail(member.getEmail());
         }
         Optional.ofNullable(member.getName())


### PR DESCRIPTION
[BE Fix] 요청자의 현재 이메일과 수정하려는 이메일이 동일할 경우에는 유효성 검증을 하지 않도록 수정하였습니다.