### PR TITLE
[FE Feat] 홈 화면 페이지 데이터 대치 (API 구현)

### DIFF
--- a/client/src/API/HomeAPI.tsx
+++ b/client/src/API/HomeAPI.tsx
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+interface EventDataType {
+  eventId: number;
+  title: string;
+  eventImageURL: string;
+  createdAt: string;
+  endAt: string;
+}
+
+interface TopRankType {
+  categoryKRName: string;
+  categoryENName: string;
+  topListURL: string;
+}
+
+export interface HomeDataType {
+  bannerImageUrl: string;
+  eventsInfo: EventDataType[];
+  topRankBanners: TopRankType[];
+}
+
+const BASE_URL = process.env.REACT_APP_BASE_URL as string;
+const accessToken = sessionStorage.getItem("accessToken");
+
+export const getHomeData = async () => {
+  try {
+    const response = await axios.get<HomeDataType>(`${BASE_URL}/home`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/API/MemberPageEdit/MemberPageEditAPI.tsx
+++ b/client/src/API/MemberPageEdit/MemberPageEditAPI.tsx
@@ -1,8 +1,5 @@
 import axios from "axios";
 
-// 로그인 기능 일부 미구현으로 이후 기능 완료 시 해당 데이터 삭제
-const accessToken = sessionStorage.getItem("accessToken");
-
 export interface AddressType {
   addressId: number;
   isPrimary: boolean;
@@ -49,6 +46,7 @@ interface UpdateMemberDataType {
 }
 
 const BASE_URL = process.env.REACT_APP_BASE_URL as string;
+const accessToken = sessionStorage.getItem("accessToken");
 
 export const getMemberData = async (memberId: number) => {
   try {

--- a/client/src/Pages/Home.tsx
+++ b/client/src/Pages/Home.tsx
@@ -1,8 +1,9 @@
 import dummyData from "./../data/HomeData.json";
 import styled from "styled-components";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import "./Style/home.css";
+import { getHomeData, HomeDataType } from "../API/HomeAPI";
 
 const HeroImage = styled.div<{ bgUrl: string }>`
   background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
@@ -52,33 +53,47 @@ const TopSalesContent = styled.div<{ bgUrl: string }>`
 `;
 
 export default function Home() {
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const [homeData, setHomeData] = useState<HomeDataType>();
   const [xPos, setXPos] = useState(0);
   const [carouselStyleToSlide, setCarouselStyleToSlide] = useState({
     transform: `translateX(${xPos}px)`,
   });
 
   useEffect(() => {
+    try {
+      getHomeData().then((res) => {
+        setHomeData(res);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
+
+  useEffect(() => {
     setCarouselStyleToSlide({ transform: `translateX(${xPos}px)` });
   }, [xPos]);
 
   const slideCarousel = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const carouselWidth = carouselRef.current?.clientWidth as number;
     const arrowButton: HTMLButtonElement = event.currentTarget;
-    const maxXPos: number = -1000 * (dummyData.eventsInfo.length - 1);
+    const maxXPos: number = -carouselWidth * (dummyData.eventsInfo.length - 1);
 
     if (arrowButton.name === "left" && xPos === 0) {
       setXPos(maxXPos);
     } else if (arrowButton.name === "left" && xPos !== 0) {
-      setXPos(xPos + 1000);
+      setXPos(xPos + carouselWidth);
     } else if (arrowButton.name === "right" && xPos === maxXPos) {
       setXPos(0);
     } else if (arrowButton.name === "right" && xPos > maxXPos) {
-      setXPos(xPos - 1000);
+      setXPos(xPos - carouselWidth);
     }
   };
 
   return (
     <div className="Home_Container">
-      <HeroImage bgUrl={dummyData.bannerImageUrl}>
+      {/* 현재 이미지가 없어서 dummyData 활용, 이후 이미지 추가 시 해당 데이터는 삭제 (get 요청은 정상적으로 작동 중이고 데이터가 잘 들어오는지 확인 완료) */}
+      <HeroImage bgUrl={dummyData?.bannerImageUrl as string}>
         <div className="Hero_Text">
           <h1 className="Hero_Text_Gradient">남성 전용 화장품</h1>
           <p className="Hero_Text_Gradient">
@@ -94,15 +109,16 @@ export default function Home() {
           ◀
         </button>
         <div className="Events_Carousel">
-          {dummyData.eventsInfo.map((a) => {
+          {dummyData?.eventsInfo.map((a, idx) => {
             return (
               <CarouselSlide
                 bgUrl={a.eventImageURL}
                 key={`slide${a.eventId}`}
                 style={carouselStyleToSlide}
+                ref={carouselRef}
               >
                 <div className="Event_Number_Text">
-                  {a.eventId} / {dummyData.eventsInfo.length}
+                  {idx + 1} / {dummyData.eventsInfo.length}
                 </div>
                 <div className="Event_Caption_Text">
                   <Link to="/events/:eventId">
@@ -119,7 +135,7 @@ export default function Home() {
         </button>
       </div>
       <div className="Top_Sales_Banner">
-        {dummyData.topRankBanners.map((a, idx) => {
+        {homeData?.topRankBanners.map((a, idx) => {
           return (
             <Link
               to="/items-top-list"

--- a/client/src/Pages/Style/home.css
+++ b/client/src/Pages/Style/home.css
@@ -49,7 +49,7 @@
 
 .Events_Carousel {
   height: 100%;
-  width: 1000px;
+  width: 100%;
   display: flex;
   overflow-x: scroll;
   scroll-behavior: smooth;


### PR DESCRIPTION

![화면 기록 2023-01-26 오후 6 16 23](https://user-images.githubusercontent.com/61323917/214799904-cf47e524-7515-4232-abfe-a39631ee635a.gif)


### **구현한 기능**

- 홈 화면 데이터 연동
- 이벤트 베너 슬라이드 오류 수정

### **공유해야할 사항**

- 현재 서버데이터에 메인 베너 이미지와 이벤트 베너 이미지들이 없어서 기존 더미데이터를 사용했습니다. (데이터는 잘 들어오는 것 확인했습니다.) 주석 달아놓았듯이 이후 서버데이터에 이미지 URL 정상적으로 들어왔을 때 최종적으로 데이터 대치하고 더미데이터 삭제하겠습니다.
- 추가적인 리팩토링은 디자인 단계에서 한 번 더 다듬을 예정입니다.