### PR TITLE
[BE FEAT] 자동결제를 위한 SID 필드추가 

### DIFF
--- a/server/src/main/java/com/seb_main_002/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_002/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.seb_main_002.exception.ExceptionCode;
 import com.seb_main_002.member.dto.MemberMailRequestDto;
 import com.seb_main_002.member.dto.MemberPatchDto;
 import com.seb_main_002.member.dto.MemberPostDto;
+import com.seb_main_002.member.dto.SIDResponseDto;
 import com.seb_main_002.member.entity.Member;
 import com.seb_main_002.member.mapper.MemberMapper;
 import com.seb_main_002.member.repository.MemberRepository;
@@ -38,10 +39,17 @@ public class MemberController {
     public ResponseEntity subscribe(@PathVariable("memberId") Long memberId,
                                     @Valid @RequestBody MemberPatchDto requestBody) {
         Boolean isSubscribed = requestBody.getIsSubscribed();
-        memberService.updateSubscribe(memberId, isSubscribed);
+        String SID = requestBody.getSID();
+        memberService.updateSubscribe(memberId, isSubscribed, SID);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @GetMapping("/members/{memberId}/subscribe")
+    public ResponseEntity getSID(@PathVariable("memberId") Long memberId){
+        Member member = memberService.findMember(memberId);
+        SIDResponseDto response = new SIDResponseDto(member.getSubscribe().getSID());
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
     @GetMapping("/members/{memberId}")
     public ResponseEntity getMember(@PathVariable("memberId") Long memberId) {
         Member member = memberService.findMember(memberId);

--- a/server/src/main/java/com/seb_main_002/member/dto/MemberPatchDto.java
+++ b/server/src/main/java/com/seb_main_002/member/dto/MemberPatchDto.java
@@ -22,4 +22,5 @@ public class MemberPatchDto {
 
     private List<String> tagList;
     private Boolean isSubscribed;
+    private String SID;
 }

--- a/server/src/main/java/com/seb_main_002/member/dto/SIDResponseDto.java
+++ b/server/src/main/java/com/seb_main_002/member/dto/SIDResponseDto.java
@@ -1,0 +1,12 @@
+package com.seb_main_002.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SIDResponseDto {
+    String SID;
+
+    public SIDResponseDto(String SID) {
+        this.SID = SID;
+    }
+}

--- a/server/src/main/java/com/seb_main_002/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_002/member/service/MemberService.java
@@ -35,11 +35,10 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final CustomAuthorityUtils authorityUtils;
     private final JwtTokenizer jwtTokenizer;
-
     private final RedisService redisService;
     private final JavaMailSender javaMailSender;
     @Transactional
-    public void updateSubscribe(Long memberId, Boolean isSubScribed) {
+    public void updateSubscribe(Long memberId, Boolean isSubScribed, String SID) {
         Member member = verifyMember(memberId);
         Subscribe subscribe = member.getSubscribe();
 
@@ -51,12 +50,14 @@ public class MemberService {
                 subscribe.setReserveProfit(0);
                 subscribe.setTotalDeliveryDiscount(0);
                 subscribe.setSubscribedDate(null);
+                subscribe.setSID(null);
             } else {
                 //구독 신청의 경우
                 subscribe.setIsSubscribed(isSubScribed);
                 Integer sampleCount = subscribe.getSampleCount();
                 subscribe.setSampleCount(sampleCount + 10);
                 subscribe.setSubscribedDate(LocalDateTime.now());
+                subscribe.setSID(SID);
             }
             member.setSubscribe(subscribe);
             memberRepository.save(member);

--- a/server/src/main/java/com/seb_main_002/subscribe/entity/Subscribe.java
+++ b/server/src/main/java/com/seb_main_002/subscribe/entity/Subscribe.java
@@ -18,6 +18,8 @@ public class Subscribe extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long subscribeId;
 
+    //정기결제를 위한 결제아이디
+    private String SID;
     private Boolean isSubscribed = false;
     private Integer sampleCount = 0;
     private LocalDateTime subscribedDate;


### PR DESCRIPTION
### 정기구독 결제시 필요한 결제아이디 SID를 추가했습니다.
구현내용
- Subscribe 엔티티에 SID 필드 추가
- MemberPatchDto에 SID 필드 추가
- SIDResponseDto 생성
- Subsribe 요청시 SID 값도 같이 저장되도록 로직수정
- SID 값 요청시 필요한 핸들러메서드 작성