### PR TITLE
[BE Fix] cart에 담긴 아이템수량 변경 제한로직 추가

### DIFF
--- a/server/src/main/java/com/seb_main_002/cart/service/CartService.java
+++ b/server/src/main/java/com/seb_main_002/cart/service/CartService.java
@@ -43,19 +43,19 @@ public class CartService {
     public void updateCartItemCount(long memberId, long cartItemId, int itemCountChange){
         //변화감지를 통한 자동 db변경
         Member member = findVerifiedMember(memberId);
-
         Cart cart= member.getCart();
+        Integer itemCount;
 
         Optional<CartItem> optionalCartItem = cart.getCartItems().stream()
                 .filter(ci -> ci.getCartItemId() == cartItemId).findAny();
 
         CartItem cartItem = optionalCartItem.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CART_ITEM_NOT_FOUND));
 
+        itemCount = cartItem.getItemCount() + itemCountChange;
+        if(itemCount < 1) itemCount = 1;
 
-
-        cartItem.setItemCount(cartItem.getItemCount() + itemCountChange);
+        cartItem.setItemCount(itemCount);
         cartItem.setItemTotalPrice(cartItem.getItem().getPrice() * cartItem.getItemCount());
-
     }
 
 

--- a/server/src/main/java/com/seb_main_002/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_002/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.seb_main_002.exception.ExceptionCode;
 import com.seb_main_002.member.dto.MemberMailRequestDto;
 import com.seb_main_002.member.dto.MemberPatchDto;
 import com.seb_main_002.member.dto.MemberPostDto;
+import com.seb_main_002.member.dto.SIDResponseDto;
 import com.seb_main_002.member.entity.Member;
 import com.seb_main_002.member.mapper.MemberMapper;
 import com.seb_main_002.member.repository.MemberRepository;
@@ -38,10 +39,17 @@ public class MemberController {
     public ResponseEntity subscribe(@PathVariable("memberId") Long memberId,
                                     @Valid @RequestBody MemberPatchDto requestBody) {
         Boolean isSubscribed = requestBody.getIsSubscribed();
-        memberService.updateSubscribe(memberId, isSubscribed);
+        String SID = requestBody.getSID();
+        memberService.updateSubscribe(memberId, isSubscribed, SID);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @GetMapping("/members/{memberId}/subscribe")
+    public ResponseEntity getSID(@PathVariable("memberId") Long memberId){
+        Member member = memberService.findMember(memberId);
+        SIDResponseDto response = new SIDResponseDto(member.getSubscribe().getSID());
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
     @GetMapping("/members/{memberId}")
     public ResponseEntity getMember(@PathVariable("memberId") Long memberId) {
         Member member = memberService.findMember(memberId);

--- a/server/src/main/java/com/seb_main_002/member/dto/MemberPatchDto.java
+++ b/server/src/main/java/com/seb_main_002/member/dto/MemberPatchDto.java
@@ -22,4 +22,5 @@ public class MemberPatchDto {
 
     private List<String> tagList;
     private Boolean isSubscribed;
+    private String SID;
 }

--- a/server/src/main/java/com/seb_main_002/member/dto/SIDResponseDto.java
+++ b/server/src/main/java/com/seb_main_002/member/dto/SIDResponseDto.java
@@ -1,0 +1,12 @@
+package com.seb_main_002.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SIDResponseDto {
+    String SID;
+
+    public SIDResponseDto(String SID) {
+        this.SID = SID;
+    }
+}

--- a/server/src/main/java/com/seb_main_002/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_002/member/service/MemberService.java
@@ -35,11 +35,10 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final CustomAuthorityUtils authorityUtils;
     private final JwtTokenizer jwtTokenizer;
-
     private final RedisService redisService;
     private final JavaMailSender javaMailSender;
     @Transactional
-    public void updateSubscribe(Long memberId, Boolean isSubScribed) {
+    public void updateSubscribe(Long memberId, Boolean isSubScribed, String SID) {
         Member member = verifyMember(memberId);
         Subscribe subscribe = member.getSubscribe();
 
@@ -51,12 +50,14 @@ public class MemberService {
                 subscribe.setReserveProfit(0);
                 subscribe.setTotalDeliveryDiscount(0);
                 subscribe.setSubscribedDate(null);
+                subscribe.setSID(null);
             } else {
                 //구독 신청의 경우
                 subscribe.setIsSubscribed(isSubScribed);
                 Integer sampleCount = subscribe.getSampleCount();
                 subscribe.setSampleCount(sampleCount + 10);
                 subscribe.setSubscribedDate(LocalDateTime.now());
+                subscribe.setSID(SID);
             }
             member.setSubscribe(subscribe);
             memberRepository.save(member);

--- a/server/src/main/java/com/seb_main_002/subscribe/entity/Subscribe.java
+++ b/server/src/main/java/com/seb_main_002/subscribe/entity/Subscribe.java
@@ -18,6 +18,8 @@ public class Subscribe extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long subscribeId;
 
+    //정기결제를 위한 결제아이디
+    private String SID;
     private Boolean isSubscribed = false;
     private Integer sampleCount = 0;
     private LocalDateTime subscribedDate;


### PR DESCRIPTION
Cart에 담긴 아이템수량이 1 미만으로 떨어지는 요청이 들어왔을때 1로 고정되게끔 로직을 추가했습니다.