### PR TITLE
[BE Fix] post Tag 오류 수정

### DIFF
--- a/server/src/main/java/com/seb_main_002/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_002/member/service/MemberService.java
@@ -96,9 +96,11 @@ public class MemberService {
     public void updateMember(Long memberId, Member member) {
         Member verifedMember = verifyMember(memberId);
 
-        // 기존 이메일과 동일할 경우에는 유효성 검증을 하지 않도록 수정하였습니다.
-        if(!member.getEmail().equals(verifedMember.getEmail())) {
-            verifyExistsEmail(member.getEmail());
+        if(member.getEmail() != null) {
+            // 기존 이메일과 동일할 경우에는 유효성 검증을 하지 않도록 수정하였습니다.
+            if(!member.getEmail().equals(verifedMember.getEmail())) {
+                verifyExistsEmail(member.getEmail());
+            }
         }
         Optional.ofNullable(member.getName())
                 .ifPresent(name -> verifedMember.setName(name));


### PR DESCRIPTION
member 개인정보를 수정 시 기존 이메일과 동일할 경우에는 유효성 검증을 하지 않도록 수정하였었습니다. 
-> 해당 로직 추가로 tag 등록 시 에러가 발생하게 되었습니다. 해당 부분을 수정하기 위해 코드를 추가하였습니다.