### PR TITLE
[FE Feat] 이벤트 페이지 Get 요청에 따른 데이터 대치

### DIFF
--- a/client/src/API/Event/EventAPI.tsx
+++ b/client/src/API/Event/EventAPI.tsx
@@ -1,0 +1,19 @@
+import { defaultInstance } from "../Core";
+
+export interface EventType {
+  eventId: number;
+  title: string;
+  content: string;
+  eventImageURL: string;
+  createdAt: string;
+  endAt: string;
+}
+
+export const getEventData = async (eventId: number) => {
+  try {
+    const response = await defaultInstance.get<EventType>(`/event/${eventId}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/API/Home/HomeAPI.tsx
+++ b/client/src/API/Home/HomeAPI.tsx
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { defaultInstance } from "../Core";
 
 interface EventDataType {

--- a/client/src/Pages/EventDetail.tsx
+++ b/client/src/Pages/EventDetail.tsx
@@ -1,40 +1,37 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { EventType, getEventData } from "../API/Event/EventAPI";
 import "./Style/eventDetail.css";
 
 export default function EventDetail() {
+  const eventId = useParams();
+  const [event, setEvent] = useState<EventType>();
+
+  useEffect(() => {
+    try {
+      getEventData(Number(eventId)).then((res) => {
+        console.log(res);
+        setEvent(res);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
   return (
     <div>
-      <h1 className="Event_Title">이벤트 제목</h1>
-      <div className="Event_Posted_Date">2023.01.10</div>
+      <h1 className="Event_Title">{event?.title}</h1>
+      <div className="Event_Posted_Date">{event?.createdAt}</div>
 
       <div className="Event_Image">
-        <img src="https://picsum.photos/1000/500" alt="sample image"></img>
+        <img src={event?.eventImageURL} alt="event image"></img>
       </div>
 
       <div>
         <div className="Event_Term">
           기간:
-          <span>2023.01.10</span> ~ <span>2023.02.03</span>
+          <span>{event?.createdAt}</span> ~ <span>{event?.endAt}</span>
         </div>
-        <div className="Event_Detail">
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Id
-            repellat sed quaerat exercitationem enim dolore ratione dolorem?
-            Odio ab temporibus excepturi, at neque, consequatur aliquam labore,
-            mollitia error perspiciatis vero! Lorem ipsum dolor sit amet,
-            consectetur adipisicing elit. Id repellat sed quaerat exercitationem
-            enim dolore ratione dolorem? Odio ab temporibus excepturi, at neque,
-            consequatur aliquam labore, mollitia error perspiciatis vero!
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Id
-            repellat sed quaerat exercitationem enim dolore ratione dolorem?
-            Odio ab temporibus excepturi, at neque, consequatur aliquam labore,
-            mollitia error perspiciatis vero! Lorem ipsum dolor sit amet,
-            consectetur adipisicing elit. Id repellat sed quaerat exercitationem
-            enim dolore ratione dolorem? Odio ab temporibus excepturi, at neque,
-            consequatur aliquam labore, mollitia error perspiciatis vero!
-          </p>
-        </div>
+        <div className="Event_Detail">{event?.content}</div>
       </div>
     </div>
   );

--- a/client/src/Pages/Home.tsx
+++ b/client/src/Pages/Home.tsx
@@ -121,7 +121,7 @@ export default function Home() {
                   {idx + 1} / {dummyData.eventsInfo.length}
                 </div>
                 <div className="Event_Caption_Text">
-                  <Link to="/events/:eventId">
+                  <Link to={`/events/${a.eventId}`}>
                     <h4 className="Event_Title">{a.title}</h4>
                   </Link>
                   <p>{`${a.createdAt} ~ ${a.endAt}`}</p>


### PR DESCRIPTION
### **구현한 기능**

- EventAPI 파일 구성 및 axios 요청 추가
- 각 데이터 기존 내 정보 페이지 더미데이터 대치 및 더미데이터 삭제

### **공유해야할 사항**

- 현재 Home에서의 get 요청이 bannerImageURL 부재로 404 에러가 발생하고 있어 이벤트 페이지에서 데이터 확인을 할 수 없습니다. 해당 get 요청이 수정되면 확인할 수 있습니다.