### PR TITLE
[BE Feat] POST_order_API 요청 검증 로직 추가

### DIFF
--- a/server/src/main/java/com/seb_main_002/order/controller/OrderController.java
+++ b/server/src/main/java/com/seb_main_002/order/controller/OrderController.java
@@ -5,6 +5,8 @@ import com.seb_main_002.order.dto.OrderPostDto;
 import com.seb_main_002.order.entity.Order;
 import com.seb_main_002.order.mapper.OrderMapper;
 import com.seb_main_002.order.service.OrderService;
+import com.seb_main_002.security.jwt.JwtVerificationFilter;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -13,7 +15,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/orders")
@@ -21,19 +25,27 @@ import javax.validation.Valid;
 public class OrderController {
     private OrderMapper mapper;
     private OrderService orderService;
+    private final JwtVerificationFilter jwtVerificationFilter;
 
     public OrderController(OrderMapper mapper,
-                           OrderService orderService) {
+                           OrderService orderService,
+                           JwtVerificationFilter jwtVerificationFilter) {
         this.mapper = mapper;
         this.orderService = orderService;
+        this.jwtVerificationFilter = jwtVerificationFilter;
     }
 
     @PostMapping
-    public ResponseEntity postOrder(@Valid @RequestBody OrderPostDto orderPostDto) {
+    public ResponseEntity postOrder(@Valid @RequestBody OrderPostDto orderPostDto,
+                                    HttpServletRequest request) {
+
+        Map<String, Object> response = jwtVerificationFilter.verifyJws(request);
+        Long tokenMemberId = ((Number)response.get("memberId")).longValue();
+
         Order order = mapper.orderPostDtoToOrder(orderPostDto);
         OrderInfoDto orderInfoDto = mapper.orderPostDtoToOrderInfo(orderPostDto);
 
-        orderService.createOrder(order, orderInfoDto);
+        orderService.createOrder(tokenMemberId, order, orderInfoDto);
 
         return new ResponseEntity<> (HttpStatus.OK);
     }

--- a/server/src/main/java/com/seb_main_002/order/service/OrderService.java
+++ b/server/src/main/java/com/seb_main_002/order/service/OrderService.java
@@ -34,8 +34,10 @@ public class OrderService {
         this.itemRepository = itemRepository;
     }
 
-    public void createOrder(Order order, OrderInfoDto orderInfoDto) {
+    public void createOrder(Long tokenMemberId, Order order, OrderInfoDto orderInfoDto) {
         Long memberId = order.getMember().getMemberId();
+
+        if(!tokenMemberId.equals(memberId)) throw new BusinessLogicException(ExceptionCode.CANNOT_POST_ORDER);
 
         Member member = verifyMember(memberId);
         boolean isSubscribed = member.getSubscribe().getIsSubscribed();


### PR DESCRIPTION
1. 추가 기능
 - requestBody의 memberId와 token의 memberId를 비교하여 일치할 경우에만 주문을 넣을 수 있도록 검증 로직 추가