### PR TITLE
[FE Hotfix] 내 정보 페이지

### DIFF
--- a/client/src/Components/Commons/Header.tsx
+++ b/client/src/Components/Commons/Header.tsx
@@ -9,13 +9,13 @@ import { kakaoRegularPayment } from "../../API/SubscriptionAPI";
 
 export default function Header() {
   const [isDropdownClicked, setIsDropdownClicked] = useState(false);
-  const [isCheckBoxClick, setIsCheckBoxClick] = useState(false);
+  const [isCheckBoxClicked, setIsCheckBoxClicked] = useState(false);
 
   const memberId = sessionStorage.getItem("memberId");
   const navigate = useNavigate();
 
   const toggleDropdown = () => {
-    setIsCheckBoxClick(!isCheckBoxClick);
+    setIsCheckBoxClicked(!isCheckBoxClicked);
     setIsDropdownClicked(!isDropdownClicked);
   };
 
@@ -88,7 +88,7 @@ export default function Header() {
             <input
               type="checkbox"
               id="Nav_Menu"
-              checked={isCheckBoxClick}
+              checked={isCheckBoxClicked}
               onChange={toggleDropdown}
             />
             <span></span>
@@ -103,7 +103,8 @@ export default function Header() {
               <li>
                 <div className="Nav_Line"></div>
               </li>
-              {itemList.map((item, index) => {
+              {/* 해당 코드는 이후 수정 예정 */}
+              {/* {itemList.map((item, index) => {
                 return (
                   <li key={index} onClick={toggleDropdown}>
                     <Link to={`/items-list/${item.itemNameEN}`}>
@@ -111,12 +112,13 @@ export default function Header() {
                     </Link>
                   </li>
                 );
-              })}
-              <li>
-                <div className="Nav_Line"></div>
-              </li>
+              })} */}
+
               <li onClick={toggleDropdown}>
                 <Link to="/items-top-list/all">추천 리스트</Link>
+              </li>
+              <li>
+                <div className="Nav_Line"></div>
               </li>
             </ul>
           ) : null}

--- a/client/src/Components/MyPageComponent/OrderHistoryItem.tsx
+++ b/client/src/Components/MyPageComponent/OrderHistoryItem.tsx
@@ -59,6 +59,19 @@ const OrderHistoryItem = ({ order }: { order: OrderType }) => {
                   <span className="History_Detail_Indicator">가격</span>
                   <div>{item.itemTotalPrice}</div>
                 </div>
+                <div>
+                  <Link to={`/reviews/item/${item.itemId}`}>
+                    <CustomButton
+                      bgColor="transparent"
+                      content="리뷰 작성"
+                      width="100px"
+                      padding="10px"
+                      fontColor="gold"
+                      border="none"
+                      fontsize="19px"
+                    />
+                  </Link>
+                </div>
               </div>
             );
           })}

--- a/client/src/Components/Style/header.css
+++ b/client/src/Components/Style/header.css
@@ -52,7 +52,7 @@
 .Nav_List {
   position: absolute;
   width: 200px;
-  height: 245px;
+  height: 120px;
   background-color: var(--dark2);
   left: -40px;
   top: 65px;
@@ -61,17 +61,18 @@
   z-index: 10;
 }
 
-.Nav_List li{
+.Nav_List li {
   display: flex;
   justify-content: center;
-  margin: 5px 0;
+  margin: 10px 0;
+  font-size: 23px;
 }
 
-.Nav_Line{
+.Nav_Line {
   width: 80%;
   height: 2px;
   border-radius: 4px;
-  background-color: var(--dark);
+  background-color: lightblue;
 }
 
 .Header_Logo {

--- a/client/src/Pages/Home.tsx
+++ b/client/src/Pages/Home.tsx
@@ -108,11 +108,11 @@ export default function Home() {
           ◀
         </button>
         <div className="Events_Carousel">
-          {homeData?.eventsInfo.map((a, idx) => {
+          {homeData?.eventsInfo.map((event, idx) => {
             return (
               <CarouselSlide
-                bgUrl={a.eventImageURL}
-                key={`slide${a.eventId}`}
+                bgUrl={event.eventImageURL}
+                key={`slide${event.eventId}`}
                 style={carouselStyleToSlide}
                 ref={carouselRef}
               >
@@ -120,10 +120,10 @@ export default function Home() {
                   {idx + 1} / {homeData.eventsInfo.length}
                 </div>
                 <div className="Event_Caption_Text">
-                  <Link to={`/events/${a.eventId}`}>
-                    <h4 className="Event_Title">{a.title}</h4>
+                  <Link to={`/events/${event.eventId}`}>
+                    <h4 className="Event_Title">{event.title}</h4>
                   </Link>
-                  <p>{`${a.createdAt} ~ ${a.endAt}`}</p>
+                  <p>{`${event.createdAt} ~ ${event.endAt}`}</p>
                 </div>
               </CarouselSlide>
             );
@@ -134,15 +134,15 @@ export default function Home() {
         </button>
       </div>
       <div className="Top_Sales_Banner">
-        {homeData?.topRankBanners.map((a, idx) => {
+        {homeData?.topRankBanners.map((topRankCategory, idx) => {
           return (
             <Link
-              to={`/items-top-list/${a.categoryENName}`}
+              to={`/items-top-list/${topRankCategory.categoryENName}`}
               className="Top_Sales"
               key={`topSales${idx}`}
             >
-              <TopSalesContent bgUrl={a.topListURL}>
-                <p>이 달의 Top 10 {a.categoryKRName}</p>
+              <TopSalesContent bgUrl={topRankCategory.topListURL}>
+                <p>이 달의 Top 10 {topRankCategory.categoryKRName}</p>
               </TopSalesContent>
             </Link>
           );

--- a/client/src/Pages/MemberPage.tsx
+++ b/client/src/Pages/MemberPage.tsx
@@ -126,7 +126,7 @@ const MemberPage = () => {
                 profileData?.tagList
                   .slice(2, profileData?.tagList.length)
                   .map((tag, idx) => {
-                    return <> {SkinTag(tag)}</>;
+                    return <span key={`tag${idx}`}> {SkinTag(tag)}</span>;
                   })
               ) : (
                 <span className="No_Tags">추가 태그 없음</span>

--- a/client/src/Pages/MemberPageEdit.tsx
+++ b/client/src/Pages/MemberPageEdit.tsx
@@ -44,7 +44,6 @@ export default function MemberPageEdit() {
 
   // 각 인풋 태그의 필드값 => 객체 상태에서 값을 불러올 시 문제가 발생하여 patch 메서드 사용 및 Input값 onChange 이벤트 핸들링을 위해 각 상태를 선언, 할당해 사용
   const [memberName, setMemberName] = useState<string | undefined>("");
-  const [birthdate, setBirthDate] = useState<string | undefined>("");
   const [email, setEmail] = useState<string | undefined>("");
   const [phoneNumber, setPhoneNumber] = useState<string | undefined>("");
   const [tagList, setTagList] = useState<string[] | undefined>([]);
@@ -77,13 +76,12 @@ export default function MemberPageEdit() {
   useEffect(() => {
     try {
       getMemberData(memberId).then((res) => {
+        setRender(true);
         setMemberAddressData(res);
         setMemberName(res?.memberName);
-        setBirthDate(res?.birthdate);
         setEmail(res?.email);
         setPhoneNumber(res?.phoneNumber);
         setTagList(res?.tagList);
-        setRender(!render);
       });
     } catch (err) {
       console.error(err);
@@ -92,15 +90,6 @@ export default function MemberPageEdit() {
 
   const handleMemberName: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setMemberName(e.target.value);
-  };
-
-  const handleBirthDate: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    setBirthDate(
-      e.target.value
-        .replace(/[^0-9]/g, "")
-        .replace(/^(\d{0,4})(\d{0,2})(\d{0,2})$/g, "$1/$2/$3")
-        .replace(/(\/{1,2})$/g, "")
-    );
   };
 
   const handleEmail: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -117,11 +106,9 @@ export default function MemberPageEdit() {
   };
 
   const editSkinType: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
-    // 검사를 위한 값
     const sebumType = ["건성", "복합성", "지성"];
-    const skinType = ["일반 피부", "여드름성 피부"];
+    const skinType = ["일반피부", "여드름성 피부"];
 
-    // 1, 2 번째 필드값 변동시 tagList 변경
     if (sebumType.includes(e.target.value) && tagList) {
       tagList[0] = e.target.value;
     }
@@ -161,8 +148,8 @@ export default function MemberPageEdit() {
     };
     if (window.confirm("대표 주소로 변경하시겠습니까?")) {
       updateAddress(addressId, addressData);
-      alert("대표주소로 변경 완료");
       setRender(!render);
+      alert("대표주소로 변경 완료");
     }
   };
 
@@ -185,8 +172,8 @@ export default function MemberPageEdit() {
 
     if (window.confirm("해당 주소지를 삭제하시겠습니까?")) {
       deleteAddress(addressId);
-      alert("삭제가 완료되었습니다.");
       setRender(!render);
+      alert("삭제가 완료되었습니다.");
     }
   };
 
@@ -199,10 +186,18 @@ export default function MemberPageEdit() {
     };
 
     if (window.confirm("수정하시겠습니까?")) {
-      updateMemberData(memberId, reqBody);
-      setRender(!render);
-      alert("수정 완료");
-      navigate(`/memberPage/${memberId}`);
+      if (email?.includes("@") === false) {
+        alert("이메일은 도메인(@)을 포함해야 합니다.");
+      } else if (phoneNumber?.slice(0, 3) !== "010") {
+        alert("핸드폰 번호는 010으로 시작해야 합니다.");
+      } else if (phoneNumber?.length !== 13) {
+        alert("핸드폰 번호는 010을 포함한 총 11자리가 되어야 합니다.");
+      } else {
+        updateMemberData(memberId, reqBody);
+        setRender(!render);
+        alert("수정 완료");
+        navigate(`/memberPage/${memberId}`);
+      }
     }
   };
 
@@ -210,8 +205,8 @@ export default function MemberPageEdit() {
     if (window.confirm("정말 구독을 취소하시겠습니까?")) {
       cancelSubscription(memberId);
       setIsSubscribed(false);
-      alert("구독이 취소되었습니다.");
       setRender(!render);
+      alert("구독이 취소되었습니다.");
     }
   };
 
@@ -282,13 +277,7 @@ export default function MemberPageEdit() {
           <InfoWrapper>
             <div className="Info_Label">생년월일</div>
             <div className="Info_Content">
-              <input
-                className="Info_Input"
-                type="text"
-                maxLength={10}
-                value={birthdate}
-                onChange={handleBirthDate}
-              />
+              {memberAddressData && memberAddressData.birthdate}
             </div>
           </InfoWrapper>
           <InfoWrapper>
@@ -311,6 +300,7 @@ export default function MemberPageEdit() {
                 maxLength={13}
                 value={phoneNumber}
                 onChange={handlePhoneNumber}
+                required
               />
             </div>
           </InfoWrapper>
@@ -418,9 +408,27 @@ export default function MemberPageEdit() {
                 <div className="Info_Label">피지 타입</div>
                 <div className="Info_Content">
                   <select className="Type_Dropdown" onChange={editSkinType}>
-                    <option value="건성">건성</option>
-                    <option value="지성">지성</option>
-                    <option value="복합성">복합성</option>
+                    {tagList && tagList[0] === "건성" ? (
+                      <option value="건성" selected>
+                        건성
+                      </option>
+                    ) : (
+                      <option value="건성">건성</option>
+                    )}
+                    {tagList && tagList[0] === "지성" ? (
+                      <option value="지성" selected>
+                        지성
+                      </option>
+                    ) : (
+                      <option value="지성">지성</option>
+                    )}
+                    {tagList && tagList[0] === "복합성" ? (
+                      <option value="복합성" selected>
+                        복합성
+                      </option>
+                    ) : (
+                      <option value="복합성">복합성</option>
+                    )}
                   </select>
                 </div>
               </InfoWrapper>
@@ -428,8 +436,20 @@ export default function MemberPageEdit() {
                 <div className="Info_Label">피부 타입</div>
                 <div className="Info_Content">
                   <select className="Type_Dropdown" onChange={editSkinType}>
-                    <option value="일반 피부">일반 피부</option>
-                    <option value="여드름성 피부">여드름성 피부</option>
+                    {tagList && tagList[1] === "일반피부" ? (
+                      <option value="일반피부" selected>
+                        일반피부
+                      </option>
+                    ) : (
+                      <option value="일반피부">일반피부</option>
+                    )}
+                    {tagList && tagList[1] === "여드름성 피부" ? (
+                      <option value="여드름성 피부" selected>
+                        여드름성 피부
+                      </option>
+                    ) : (
+                      <option value="여드름성 피부">여드름성 피부</option>
+                    )}
                   </select>
                 </div>
               </InfoWrapper>

--- a/client/src/Pages/MemberPageEdit.tsx
+++ b/client/src/Pages/MemberPageEdit.tsx
@@ -13,7 +13,7 @@ import NewAddressModal from "../Components/MemberPageEdit/NewAddressModal";
 import EditAddressModal from "../Components/MemberPageEdit/EditAddressModal";
 import { subscriptionCalculation } from "../Function/memberEditPage";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import "./Style/memberPageEdit.css";
 
@@ -33,6 +33,7 @@ const InfoWrapper = styled.div`
 const memberId = Number(sessionStorage.getItem("memberId"));
 
 export default function MemberPageEdit() {
+  const navigate = useNavigate();
   const [modalState, setModalState] = useState(false);
   // modal 컴포넌트의 element에 들어갈 컴포넌트를 결정하는 변수
   const [isNewAddressModalOn, setIsNewAddressModalOn] = useState(false);
@@ -82,6 +83,7 @@ export default function MemberPageEdit() {
         setEmail(res?.email);
         setPhoneNumber(res?.phoneNumber);
         setTagList(res?.tagList);
+        setRender(!render);
       });
     } catch (err) {
       console.error(err);
@@ -198,8 +200,9 @@ export default function MemberPageEdit() {
 
     if (window.confirm("수정하시겠습니까?")) {
       updateMemberData(memberId, reqBody);
-      alert("수정 완료");
       setRender(!render);
+      alert("수정 완료");
+      navigate(`/memberPage/${memberId}`);
     }
   };
 


### PR DESCRIPTION
다음 문제 해결

1. 내 정보 수정 페이지

- 생년월일 수정 불가
- 주소지 추가/수정/삭제 등 화면 새로고침이 안되던 현상 해결
- 내 정보 수정 완료 시 유효성 검사 구현
- 피부타입 “일반피부”로 통일, 내 피부타입 정보가 수정 페이지에서 반영이 안되던 현상 해결

2. 내 정보 페이지 : 내 주문 내역 리뷰 버튼 추가

3. 공용 컴포넌트 헤더 : 현재 기능성 구현을 위해 일부 내용 삭제 및 css 수정