### PR TITLE
[BE Feat] login post API 요청 시 응답 필드 추가

### DIFF
--- a/server/src/main/java/com/seb_main_002/security/CustomUserDetailsService.java
+++ b/server/src/main/java/com/seb_main_002/security/CustomUserDetailsService.java
@@ -43,6 +43,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 setPhoneNumber(member.getPhoneNumber());
                 setPassword(member.getPassword());
                 setRoles(member.getRoles());
+                setSubscribe(member.getSubscribe());
             }
 
             @Override

--- a/server/src/main/java/com/seb_main_002/security/dto/LoginResponseDto.java
+++ b/server/src/main/java/com/seb_main_002/security/dto/LoginResponseDto.java
@@ -1,0 +1,16 @@
+package com.seb_main_002.security.dto;
+
+import com.seb_main_002.security.jwt.TokenInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDto {
+    private TokenInfo tokenInfo;
+
+    private Boolean isSubscribed;
+
+    private String subscribedDate;
+
+}

--- a/server/src/main/java/com/seb_main_002/security/jwt/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/seb_main_002/security/jwt/JwtAuthenticationFilter.java
@@ -4,8 +4,10 @@ import antlr.Token;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seb_main_002.member.entity.Member;
 import com.seb_main_002.security.dto.LoginDto;
+import com.seb_main_002.security.dto.LoginResponseDto;
 import com.seb_main_002.security.redis.RedisService;
 import com.seb_main_002.security.util.ErrorResponder;
+import com.seb_main_002.subscribe.entity.Subscribe;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
@@ -19,6 +21,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,8 +73,19 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 .accessToken("Bearer " + accessToken)
                 .refreshToken(refreshToken)
                 .build();
+
+        Subscribe subscribeInfo = member.getSubscribe();
+        Boolean isSubscribed = subscribeInfo.getIsSubscribed();
+        String subscribedDate = isSubscribed ? subscribeInfo.getSubscribedDate().format(DateTimeFormatter.ofPattern("yyyy/MM/dd/HH:mm")) : "";
+
+        LoginResponseDto loginResponseDto = LoginResponseDto.builder()
+                .tokenInfo(tokenInfo)
+                .isSubscribed(isSubscribed)
+                .subscribedDate(subscribedDate)
+                .build();
+
         ObjectMapper objectMapper = new ObjectMapper();
-        response.getWriter().write(objectMapper.writeValueAsString(tokenInfo));
+        response.getWriter().write(objectMapper.writeValueAsString(loginResponseDto));
 
         this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);
 


### PR DESCRIPTION
1. 구현 기능
 - login post api 요청 시 response에 필드 추가
 - 구독 여부 boolean 타입으로 반환
 - 구독 시 구독 날짜 반환, 구독 중이 아닐 시 빈 문자열 반환